### PR TITLE
Scenario Manager: add ports_per_vswitch in InternalTopologyConfig

### DIFF
--- a/api/proto/v1/topology.proto
+++ b/api/proto/v1/topology.proto
@@ -77,13 +77,14 @@ message InternalTopologyConfiguration {
     uint32 number_of_vhosts = 8;
     uint32 number_of_racks = 9;
     uint32 vhost_per_rack = 10;
-    string data_plane_cidr = 11;
-    uint32 number_of_gateways = 12;
-    repeated string gateway_ips = 13;
-    repeated InternalTopologyImage images = 14;
-    repeated InternalVNodeInfo vnodes = 15;
-    repeated InternalVLinkInfo vlinks = 16;
-    InternalTopologyExtraInfo extra_info = 17;
+    uint32 ports_per_vswtich = 11;
+    string data_plane_cidr = 12;
+    uint32 number_of_gateways = 13;
+    repeated string gateway_ips = 14;
+    repeated InternalTopologyImage images = 15;
+    repeated InternalVNodeInfo vnodes = 16;
+    repeated InternalVLinkInfo vlinks = 17;
+    InternalTopologyExtraInfo extra_info = 18;
 }
 
 message InternalTopologyInfo {

--- a/api/proto/v1/topology.proto
+++ b/api/proto/v1/topology.proto
@@ -77,7 +77,7 @@ message InternalTopologyConfiguration {
     uint32 number_of_vhosts = 8;
     uint32 number_of_racks = 9;
     uint32 vhost_per_rack = 10;
-    uint32 ports_per_vswtich = 11;
+    uint32 ports_per_vswitch = 11;
     string data_plane_cidr = 12;
     uint32 number_of_gateways = 13;
     repeated string gateway_ips = 14;

--- a/services/scenario-manager/entities/entities.go
+++ b/services/scenario-manager/entities/entities.go
@@ -104,6 +104,7 @@ type TopologyConfig struct {
 	NumberOfVhosts   uint          `json:"number_of_vhosts"`
 	NumberOfRacks    uint          `json:"number_of_racks"`
 	VhostsPerRack    uint          `json:"vhosts_per_rack"`
+	PortsPerVSwitch  uint          `json:"ports_per_vswitch"`
 	DataPlaneCidr    string        `json:"data_plane_cidr"`
 	NumberOfGateways uint          `json:"number_of_control_plane_gateways"`
 	GatewayIPs       []string      `json:"control_plane_gateway_ips"`

--- a/services/scenario-manager/handler/message.go
+++ b/services/scenario-manager/handler/message.go
@@ -37,6 +37,7 @@ func constructTopologyMessage(topo *entities.TopologyConfig, topoPb *topology_pb
 	conf.NumberOfVhosts = uint32(topo.NumberOfVhosts)
 	conf.NumberOfRacks = uint32(topo.NumberOfRacks)
 	conf.VhostPerRack = uint32(topo.VhostsPerRack)
+	conf.PortsPerVswtich = uint32(topo.PortsPerVSwitch)
 	conf.DataPlaneCidr = topo.DataPlaneCidr
 	conf.NumberOfGateways = uint32(topo.NumberOfGateways)
 	conf.GatewayIps = topo.GatewayIPs

--- a/services/scenario-manager/handler/message.go
+++ b/services/scenario-manager/handler/message.go
@@ -37,7 +37,7 @@ func constructTopologyMessage(topo *entities.TopologyConfig, topoPb *topology_pb
 	conf.NumberOfVhosts = uint32(topo.NumberOfVhosts)
 	conf.NumberOfRacks = uint32(topo.NumberOfRacks)
 	conf.VhostPerRack = uint32(topo.VhostsPerRack)
-	conf.PortsPerVswtich = uint32(topo.PortsPerVSwitch)
+	conf.PortsPerVswitch = uint32(topo.PortsPerVSwitch)
 	conf.DataPlaneCidr = topo.DataPlaneCidr
 	conf.NumberOfGateways = uint32(topo.NumberOfGateways)
 	conf.GatewayIps = topo.GatewayIPs


### PR DESCRIPTION
This PR make following change:
1) add `ports_per_vswitch` to `InternalTopologyConfig` protobuf
2) make the corresponding change in scenario manager's `entities.TopoConfig`
3) make the corresponding change in the constructTopology message.