### PR TITLE
Scenario Manager: Increase grpc client message size and fix scenario status for deletion

### DIFF
--- a/services/scenario-manager/grpcclient/clients.go
+++ b/services/scenario-manager/grpcclient/clients.go
@@ -45,7 +45,8 @@ func TopologyClient(topopb *topology_pb.InternalTopologyInfo) (*topology_pb.Retu
 	var conn *grpc.ClientConn
 
 	addr := constants.TOPLOGY_GRPC_SERVER_ADDRESS + ":" + strconv.Itoa(constants.TOPLOGY_GRPC_SERVER_PORT)
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(500*1024*1024), grpc.MaxCallSendMsgSize(500*1024*1024)))
 
 	if err != nil {
 		logger.Log.Errorf("can not connect to %s", err)
@@ -84,7 +85,9 @@ func NetworkClient(netconfpb *network_pb.InternalNetConfigInfo) (*network_pb.Ret
 	var conn *grpc.ClientConn
 
 	addr := constants.NETWORK_GRPC_SERVER_ADDRESS + ":" + strconv.Itoa(constants.NETWORK_GRPC_SERVER_PORT)
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(500*1024*1024), grpc.MaxCallSendMsgSize(500*1024*1024)))
+
 	if err != nil {
 		logger.Log.Errorf("can not connect to %s", err)
 		return nil, fmt.Errorf("cannot connect to merak-network grpc server: %s", err)
@@ -122,7 +125,8 @@ func ComputeClient(computepb *compute_pb.InternalComputeConfigInfo) (*compute_pb
 	var conn *grpc.ClientConn
 
 	addr := constants.COMPUTE_GRPC_SERVER_ADDRESS + ":" + strconv.Itoa(constants.COMPUTE_GRPC_SERVER_PORT)
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(500*1024*1024), grpc.MaxCallSendMsgSize(500*1024*1024)))
 	if err != nil {
 		logger.Log.Errorf("can not connect to %s", err)
 		return nil, fmt.Errorf("cannot connect to merak-compute grpc server: %s", err)

--- a/services/scenario-manager/routes/scenario.go
+++ b/services/scenario-manager/routes/scenario.go
@@ -74,7 +74,11 @@ func ScenarioActoins(c *fiber.Ctx) error {
 			scenarioStatus = entities.STATUS_FAILED
 			logger.Log.Errorf("'%s' topology failed: %s", scenarioAction.Service.Action, err.Error())
 		} else {
-			scenarioStatus = entities.STATUS_DONE
+			if scenarioAction.Service.Action == entities.EVENT_DELETE {
+				scenarioStatus = entities.STATUS_NONE
+			} else {
+				scenarioStatus = entities.STATUS_DONE
+			}
 			logger.Log.Infof("'%s' topology done.", scenarioAction.Service.Action)
 			logger.Log.Infof("returnTopo for action %s : %s", scenarioAction.Service.Action, returnTopo)
 


### PR DESCRIPTION
This PR includes two fixes:
1. increase grpc client message size to 500*1024*1024 = 500M
2. fix scenario status to `NONE` after `DELETE scenario`