### PR TITLE
Scenario Manager: add service-config into topology

### DIFF
--- a/api/proto/v1/topology.proto
+++ b/api/proto/v1/topology.proto
@@ -84,7 +84,8 @@ message InternalTopologyConfiguration {
     repeated InternalTopologyImage images = 15;
     repeated InternalVNodeInfo vnodes = 16;
     repeated InternalVLinkInfo vlinks = 17;
-    InternalTopologyExtraInfo extra_info = 18;
+    repeated common.InternalServiceInfo services = 18;
+    InternalTopologyExtraInfo extra_info = 19;
 }
 
 message InternalTopologyInfo {

--- a/services/scenario-manager/handler/deploy.go
+++ b/services/scenario-manager/handler/deploy.go
@@ -64,8 +64,13 @@ func TopologyHandler(s *entities.Scenario, action entities.EventName) (*topology
 		}
 	}
 
+	var service entities.ServiceConfig
+	if err := database.FindEntity(s.ServiceConfId, utils.KEY_PREFIX_SERVICE, &service); err != nil {
+		return nil, fmt.Errorf("service %s config not found", s.ServiceConfId)
+	}
+
 	var topoconf topology_pb.InternalTopologyInfo
-	if err := constructTopologyMessage(&topology, &topoconf, action); err != nil {
+	if err := constructTopologyMessage(&topology, &service, &topoconf, action); err != nil {
 		return nil, errors.New("topology protobuf message error")
 	}
 	logger.Log.Infof("constructTopologyMessage: %s", &topoconf)

--- a/services/scenario-manager/handler/message.go
+++ b/services/scenario-manager/handler/message.go
@@ -24,7 +24,7 @@ import (
 	"github.com/futurewei-cloud/merak/services/scenario-manager/utils"
 )
 
-func constructTopologyMessage(topo *entities.TopologyConfig, topoPb *topology_pb.InternalTopologyInfo, action entities.EventName) error {
+func constructTopologyMessage(topo *entities.TopologyConfig, serviceConf *entities.ServiceConfig, topoPb *topology_pb.InternalTopologyInfo, action entities.EventName) error {
 	topoPb.OperationType = actionToOperation(action)
 	var conf topology_pb.InternalTopologyConfiguration
 	conf.FormatVersion = 1
@@ -41,6 +41,25 @@ func constructTopologyMessage(topo *entities.TopologyConfig, topoPb *topology_pb
 	conf.DataPlaneCidr = topo.DataPlaneCidr
 	conf.NumberOfGateways = uint32(topo.NumberOfGateways)
 	conf.GatewayIps = topo.GatewayIPs
+
+	if serviceConf != nil {
+		for _, service := range serviceConf.Services {
+			var servicePb pb.InternalServiceInfo
+			if strings.ToUpper(service.WhereToRun) == utils.MERAK_AGENT {
+				servicePb.OperationType = actionToOperation(action)
+				servicePb.Id = service.Id
+				servicePb.Name = service.Name
+				servicePb.Cmd = service.Cmd
+				servicePb.Url = service.Url
+				servicePb.Parameters = service.Parameters
+				servicePb.ReturnCode = service.ReturnCode
+				servicePb.ReturnString = service.ReturnString
+				servicePb.WhenToRun = service.WhenToRun
+				servicePb.WhereToRun = service.WhereToRun
+				conf.Services = append(conf.Services, &servicePb)
+			}
+		}
+	}
 
 	for _, image := range topo.Images {
 		var imagePb topology_pb.InternalTopologyImage


### PR DESCRIPTION
Two changes in this PR:
1. add `common.InternalServiceInfo` into `topology.proto`
2. add `serviceConf` message construction in `message.go`