### PR TITLE
Merak Ntest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ services/merak-agent/build/*
 services/scenario-manager/build/*
 services/merak-topo/build/*
 services/merak-network/build/*
+services/merak-ntest/build/*

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ docker-all:
 	docker push meraksim/scenario-manager:dev
 	docker push meraksim/merak-network:dev
 	docker push meraksim/merak-topo:dev
-	docker push meraksim/merak-netst:dev
+	docker push meraksim/merak-ntest:dev
 	docker push meraksim/merak-ntest-worker:dev
 
 .PHONY: docker-all-ci
@@ -174,7 +174,7 @@ docker-all-ci:
 	docker push meraksim/merak-agent:ci
 	docker push meraksim/merak-compute:ci
 	docker push meraksim/merak-compute-vm-worker:ci
-	docker push meraksim/merak-netst:ci
+	docker push meraksim/merak-ntest:ci
 	docker push meraksim/merak-ntest-worker:ci
 	docker push meraksim/merak-network:ci
 	docker push meraksim/merak-topo:ci

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ deploy-dev:
 	kubectl apply -f deployments/kubernetes/compute.dev.yaml
 	kubectl apply -f deployments/kubernetes/network.dev.yaml
 	kubectl apply -f deployments/kubernetes/topo.dev.yaml
+	kubectl apply -f deployments/kubernetes/ntest.dev.yaml
 
 .PHONY: docker-scenario
 docker-scenario:
@@ -128,12 +129,24 @@ docker-topo:
 	docker build -t meraksim/merak-topo:dev -f docker/topo.Dockerfile .
 	docker push meraksim/merak-topo:dev
 
+.PHONY: docker-ntest
+docker-compute:
+	make proto
+	make ntest
+	make ntest-worker
+	docker build -t meraksim/merak-ntest:dev -f docker/ntest.Dockerfile .
+	docker build -t meraksim/merak-ntest-worker:dev -f docker/ntest-worker.Dockerfile .
+	docker push meraksim/merak-ntest:dev
+	docker push meraksim/merak-ntest-worker:dev
+
 
 .PHONY: docker-all
 docker-all:
 	make
 	docker build -t meraksim/merak-compute:dev -f docker/compute.Dockerfile .
 	docker build -t meraksim/merak-compute-vm-worker:dev -f docker/compute-vm-worker.Dockerfile .
+	docker build -t meraksim/merak-ntest:dev -f docker/ntest.Dockerfile .
+	docker build -t meraksim/merak-ntest-worker:dev -f docker/ntest-worker.Dockerfile .
 	docker build -t meraksim/merak-agent:dev -f docker/agent.Dockerfile .
 	docker build -t meraksim/merak-topo:dev -f docker/topo.Dockerfile .
 	docker build -t meraksim/merak-network:dev -f docker/network.Dockerfile .
@@ -144,12 +157,16 @@ docker-all:
 	docker push meraksim/scenario-manager:dev
 	docker push meraksim/merak-network:dev
 	docker push meraksim/merak-topo:dev
+	docker push meraksim/merak-netst:dev
+	docker push meraksim/merak-ntest-worker:dev
 
 .PHONY: docker-all-ci
 docker-all-ci:
 	make
 	docker build -t meraksim/merak-compute:ci -f docker/compute.Dockerfile .
 	docker build -t meraksim/merak-compute-vm-worker:ci -f docker/compute-vm-worker.Dockerfile .
+	docker build -t meraksim/merak-ntest:ci -f docker/ntest.Dockerfile .
+	docker build -t meraksim/merak-ntest-worker:ci -f docker/ntest-worker.Dockerfile .
 	docker build -t meraksim/merak-topo:ci -f docker/topo.Dockerfile .
 	docker build -t meraksim/merak-network:ci -f docker/network.Dockerfile .
 	docker build -t meraksim/scenario-manager:ci -f docker/scenario.Dockerfile .
@@ -157,6 +174,8 @@ docker-all-ci:
 	docker push meraksim/merak-agent:ci
 	docker push meraksim/merak-compute:ci
 	docker push meraksim/merak-compute-vm-worker:ci
+	docker push meraksim/merak-netst:ci
+	docker push meraksim/merak-ntest-worker:ci
 	docker push meraksim/merak-network:ci
 	docker push meraksim/merak-topo:ci
 	docker push meraksim/scenario-manager:ci
@@ -167,6 +186,7 @@ docker-all-ci:
 clean:
 	rm -rf api/proto/v1/merak/*.pb.go
 	rm -rf services/merak-compute/build/*
+	rm -rf services/merak-ntest/build/*
 	rm -rf services/merak-agent/build/*
 	rm -rf services/scenario-manager/build/*
 	rm -rf services/merak-network/build/*

--- a/api/proto/v1/agent.proto
+++ b/api/proto/v1/agent.proto
@@ -19,7 +19,7 @@ import "ntest.proto";
 
 service MerakAgentService {
     rpc PortHandler (InternalPortConfig) returns (AgentReturnInfo) {}
-    rpc TestHandler (InternalTestTargetConfig) returns (AgentReturnTestInfo) {}
+    rpc TestHandler (InternalTestConfig) returns (AgentReturnTestInfo) {}
 }
 
 message InternalPortConfig {
@@ -51,14 +51,16 @@ message AgentReturnInfo {
     ReturnPortInfo port = 3;
 }
 
-message InternalTestTargetConfig {
-    string src = 1;
-    repeated string dest = 2;
-    ntest.TestType test_type = 3;
+message InternalTestConfig {
+    ntest.TestType test_type = 1;
+    string name = 2;
+    string dest_ip = 3;
+    int32 src_port = 4;
+    int32 dest_port = 5;
 }
 
 message AgentReturnTestInfo {
     common.ReturnCode return_code = 1;
     string return_message = 2;
-    ntest.TestStatus results = 3;
+    ntest.TestStatus status = 3;
 }

--- a/api/proto/v1/ntest.proto
+++ b/api/proto/v1/ntest.proto
@@ -19,43 +19,54 @@ service MeraknTestService {
     rpc TestHandler (InternalTestConfiguration) returns (ReturnTestMessage) {}
 }
 
-enum TestStatus {
-  NONE = 0;
-  RUNNING = 1;
-  PASSED = 2;
-  FAILED = 3;
+message InternalTestConfiguration {
+    common.OperationType operation_type = 1;
+    repeated InternalVMTestInfo vms = 2;
 }
+
+//Input
 
 enum TestType {
-  PINGALL = 0;
-}
-
-message InternalTestConfiguration {
-    TestType test_type = 1;
-}
-
-message InternalTestInfo {
-    string id = 1;
-    TestType test_type = 2;
-    repeated InternalVMHost hosts = 3;
+  PING = 0;
 }
 
 message InternalVMHost {
-    string name = 1;
-    string ip = 2;
-    repeated InternalVMTestInfo vms = 3;
+    string id = 1;
+    int32 port = 2;
 }
 
+
 message InternalVMTestInfo {
-    string name = 1;
-    string id = 2;
+    InternalVMHost src = 1;
+    InternalVMHost dest = 2;
+    TestType test_type = 3;
+}
+
+//Output
+message InternalVMHostInfo {
+    string id = 1;
+    string name = 2;
     string ip = 3;
-    TestStatus results = 4;
+    int32 port = 4;
+    string host = 5;
+}
+
+message InternalVMTestResult {
+    InternalVMHostInfo src = 1;
+    InternalVMHostInfo dest = 2;
+    TestType test_type = 3;
+    TestStatus status = 4;
+}
+
+enum TestStatus {
+  RUNNING = 0;
+  PASSED = 1;
+  FAILED = 2;
 }
 
 
 message ReturnTestMessage {
     common.ReturnCode return_code = 1;
     string return_message = 2;
-    InternalTestInfo results = 3;
+    repeated InternalVMTestResult results = 3;
 }

--- a/deployments/kubernetes/merak.ci.yaml
+++ b/deployments/kubernetes/merak.ci.yaml
@@ -470,3 +470,77 @@ spec:
         ports:
         - containerPort: 6653
           name: openflow
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: merak-ntest-service
+  namespace: merak
+spec:
+  selector:
+    app: merak-ntest
+  ports:
+    - protocol: TCP
+      name: grpc
+      port: 40051
+      targetPort: ntest-grpc
+  type: ClusterIP
+---
+# Merak ntest Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merak-ntest
+  namespace: merak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merak-ntest
+  template:
+    metadata:
+      labels:
+        app: merak-ntest
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: merak-ntest
+        image: meraksim/merak-ntest:ci
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 40051
+            name: ntest-grpc
+        env:
+        - name: "TEMPORAL"
+          value: "temporaltest-frontend.default.svc.cluster.local"
+---
+# Merak Ntest Worker Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merak-ntest-worker
+  namespace: merak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merak-ntest-worker
+  template:
+    metadata:
+      labels:
+        app: merak-ntest-worker
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: merak-ntest-worker
+        image: meraksim/merak-ntest-worker:ci
+        imagePullPolicy: Always
+        env:
+        - name: "TEMPORAL"
+          value: "temporaltest-frontend.default.svc.cluster.local"

--- a/deployments/kubernetes/merak.dev.yaml
+++ b/deployments/kubernetes/merak.dev.yaml
@@ -470,3 +470,78 @@ spec:
         ports:
         - containerPort: 6653
           name: openflow
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: merak-ntest-service
+  namespace: merak
+spec:
+  selector:
+    app: merak-ntest
+  ports:
+    - protocol: TCP
+      name: grpc
+      port: 40051
+      targetPort: ntest-grpc
+  type: ClusterIP
+---
+# Merak ntest Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merak-ntest
+  namespace: merak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merak-ntest
+  template:
+    metadata:
+      labels:
+        app: merak-ntest
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: merak-ntest
+        image: meraksim/merak-ntest:dev
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 40051
+            name: ntest-grpc
+        env:
+        - name: "TEMPORAL"
+          value: "temporaltest-frontend.default.svc.cluster.local"
+---
+# Merak Ntest Worker Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merak-ntest-worker
+  namespace: merak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merak-ntest-worker
+  template:
+    metadata:
+      labels:
+        app: merak-ntest-worker
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: merak-ntest-worker
+        image: meraksim/merak-ntest-worker:dev
+        imagePullPolicy: Always
+        env:
+        - name: "TEMPORAL"
+          value: "temporaltest-frontend.default.svc.cluster.local"

--- a/deployments/kubernetes/ntest.dev.yaml
+++ b/deployments/kubernetes/ntest.dev.yaml
@@ -1,0 +1,84 @@
+# MIT License
+# Copyright(c) 2022 Futurewei Cloud
+#     Permission is hereby granted,
+#     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+#     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+#     to whom the Software is furnished to do so, subject to the following conditions:
+#     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: merak-ntest-service
+  namespace: merak
+spec:
+  selector:
+    app: merak-ntest
+  ports:
+    - protocol: TCP
+      name: grpc
+      port: 40051
+      targetPort: ntest-grpc
+  type: ClusterIP
+---
+# Merak ntest Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merak-ntest
+  namespace: merak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merak-ntest
+  template:
+    metadata:
+      labels:
+        app: merak-ntest
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: merak-ntest
+        image: meraksim/merak-ntest:dev
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 40051
+            name: ntest-grpc
+        env:
+        - name: "TEMPORAL"
+          value: "temporaltest-frontend.default.svc.cluster.local"
+---
+# Merak Ntest Worker Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: merak-ntest-worker
+  namespace: merak
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: merak-ntest-worker
+  template:
+    metadata:
+      labels:
+        app: merak-ntest-worker
+    spec:
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: merak-ntest-worker
+        image: meraksim/merak-ntest-worker:dev
+        imagePullPolicy: Always
+        env:
+        - name: "TEMPORAL"
+          value: "temporaltest-frontend.default.svc.cluster.local"

--- a/docker/ntest-worker.Dockerfile
+++ b/docker/ntest-worker.Dockerfile
@@ -1,0 +1,18 @@
+# MIT License
+# Copyright(c) 2022 Futurewei Cloud
+#     Permission is hereby granted,
+#     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+#     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+#     to whom the Software is furnished to do so, subject to the following conditions:
+#     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+FROM golang:1.18-alpine
+
+# Merak
+WORKDIR /
+RUN mkdir -p /merak-bin
+COPY services/merak-compute/build/merak-ntest-worker /merak-bin/merak-ntest-worker
+CMD [ "/merak-bin/merak-ntest-worker" ]

--- a/docker/ntest-worker.Dockerfile
+++ b/docker/ntest-worker.Dockerfile
@@ -14,5 +14,5 @@ FROM golang:1.18-alpine
 # Merak
 WORKDIR /
 RUN mkdir -p /merak-bin
-COPY services/merak-compute/build/merak-ntest-worker /merak-bin/merak-ntest-worker
+COPY services/merak-ntest/build/merak-ntest-worker /merak-bin/merak-ntest-worker
 CMD [ "/merak-bin/merak-ntest-worker" ]

--- a/docker/ntest.Dockerfile
+++ b/docker/ntest.Dockerfile
@@ -1,0 +1,18 @@
+# MIT License
+# Copyright(c) 2022 Futurewei Cloud
+#     Permission is hereby granted,
+#     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+#     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+#     to whom the Software is furnished to do so, subject to the following conditions:
+#     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+FROM golang:1.18-alpine
+
+# Merak
+WORKDIR /
+RUN mkdir -p /merak-bin
+COPY services/merak-ntest/build/merak-ntest /merak-bin/merak-ntest
+CMD [ "/merak-bin/merak-ntest" ]

--- a/services/common/constants.go
+++ b/services/common/constants.go
@@ -5,19 +5,22 @@ const (
 	TEMPORAL_PORT    = 7233
 	TEMPORAL_ENV     = "TEMPORAL"
 
+	COMPUTE_GRPC_SERVER_PORT    = 40051
 	COMPUTE_GRPC_SERVER_ADDRESS = "merak-compute-service.merak.svc.cluster.local"
 	TOPLOGY_GRPC_SERVER_PORT    = 40052
 	TOPLOGY_GRPC_SERVER_ADDRESS = "merak-topology-service.merak.svc.cluster.local"
 	NETWORK_GRPC_SERVER_PORT    = 40053
 	NETWORK_GRPC_SERVER_ADDRESS = "merak-network-service.merak.svc.cluster.local"
+	NTEST_GRPC_SERVER_PORT      = 40055
+	NTEST_GRPC_SERVER_ADDRESS   = "merak-ntest-service.merak.svc.cluster.local"
 	AGENT_GRPC_SERVER_PORT      = 40054
-	COMPUTE_GRPC_SERVER_PORT    = 40051
 
 	COMPUTE_REDIS_ADDRESS = "compute-redis-main.merak.svc.cluster.local"
 	COMPUTE_REDIS_PORT    = 30051
 
 	COMPUTE_REDIS_NODE_IP_SET = "NodeIPSet"
 	COMPUTE_REDIS_VM_SET      = "VMSet"
+	NTEST_VM_SET              = "TestVMSet"
 
 	ALCOR_PORT_MANAGER_PORT        = 30006
 	ALCOR_PORT_ID_SUBSTRING_LENGTH = 11
@@ -30,4 +33,6 @@ const (
 
 	GRPC_MAX_RECV_MSG_SIZE = 1024 * 1024 * 500
 	GRPC_MAX_SEND_MSG_SIZE = 1024 * 1024 * 500
+
+	TEST_PREFIX = "test"
 )

--- a/services/common/constants.go
+++ b/services/common/constants.go
@@ -5,15 +5,16 @@ const (
 	TEMPORAL_PORT    = 7233
 	TEMPORAL_ENV     = "TEMPORAL"
 
-	COMPUTE_GRPC_SERVER_PORT    = 40051
 	COMPUTE_GRPC_SERVER_ADDRESS = "merak-compute-service.merak.svc.cluster.local"
-	TOPLOGY_GRPC_SERVER_PORT    = 40052
+	COMPUTE_GRPC_SERVER_PORT    = 40051
 	TOPLOGY_GRPC_SERVER_ADDRESS = "merak-topology-service.merak.svc.cluster.local"
-	NETWORK_GRPC_SERVER_PORT    = 40053
+	TOPLOGY_GRPC_SERVER_PORT    = 40052
 	NETWORK_GRPC_SERVER_ADDRESS = "merak-network-service.merak.svc.cluster.local"
-	NTEST_GRPC_SERVER_PORT      = 40055
+	NETWORK_GRPC_SERVER_PORT    = 40053
 	NTEST_GRPC_SERVER_ADDRESS   = "merak-ntest-service.merak.svc.cluster.local"
-	AGENT_GRPC_SERVER_PORT      = 40054
+	NTEST_GRPC_SERVER_PORT      = 40055
+
+	AGENT_GRPC_SERVER_PORT = 40054
 
 	COMPUTE_REDIS_ADDRESS = "compute-redis-main.merak.svc.cluster.local"
 	COMPUTE_REDIS_PORT    = 30051

--- a/services/merak-agent/handler/port_create.go
+++ b/services/merak-agent/handler/port_create.go
@@ -63,7 +63,7 @@ type updatePort struct {
 	BindingHostID string `json:"binding:host_id"`
 }
 
-func caseCreate(ctx context.Context, in *pb.InternalPortConfig) (*pb.AgentReturnInfo, error) {
+func casePortCreate(ctx context.Context, in *pb.InternalPortConfig) (*pb.AgentReturnInfo, error) {
 
 	log.Println("Create Minimal Port")
 	vmInfo := pb.ReturnPortInfo{

--- a/services/merak-agent/handler/port_delete.go
+++ b/services/merak-agent/handler/port_delete.go
@@ -26,7 +26,7 @@ import (
 	constants "github.com/futurewei-cloud/merak/services/common"
 )
 
-func caseDelete(ctx context.Context, in *pb.InternalPortConfig) (*pb.AgentReturnInfo, error) {
+func casePortDelete(ctx context.Context, in *pb.InternalPortConfig) (*pb.AgentReturnInfo, error) {
 	log.Println("Send Delete Port Request to Alcor")
 
 	req, err := http.NewRequest(http.MethodDelete, "http://"+RemoteServer+":"+strconv.Itoa(constants.ALCOR_PORT_MANAGER_PORT)+"/project/"+in.Projectid+"/ports/"+in.Remoteid, bytes.NewBuffer(nil))

--- a/services/merak-compute/handler/create.go
+++ b/services/merak-compute/handler/create.go
@@ -149,6 +149,7 @@ func caseCreate(ctx context.Context, in *pb.InternalComputeConfigInfo) (*pb.Retu
 			RetryPolicy: retrypolicy,
 		}
 		log.Println("Executing VM Create Workflow with VMs ", vms.Val())
+
 		we, err := TemporalClient.ExecuteWorkflow(context.Background(), workflowOptions, create.Create, vms.Val())
 		if err != nil {
 			return &pb.ReturnComputeMessage{

--- a/services/merak-ntest/activities/ntest_create_activity.go
+++ b/services/merak-ntest/activities/ntest_create_activity.go
@@ -1,0 +1,110 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package activities
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	agent_pb "github.com/futurewei-cloud/merak/api/proto/v1/agent"
+	commonPB "github.com/futurewei-cloud/merak/api/proto/v1/common"
+	pb "github.com/futurewei-cloud/merak/api/proto/v1/ntest"
+	constants "github.com/futurewei-cloud/merak/services/common"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/common"
+	"go.temporal.io/sdk/activity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// Creates a VM given by the vmID
+func NtestCreate(ctx context.Context, vm *pb.InternalVMTestInfo) error {
+	logger := activity.GetLogger(ctx)
+	logger.Info("Starting Ntest create activity for VM " + vm.Src.Id)
+
+	var agent_address strings.Builder
+	podIP := common.RedisClient.HGet(ctx, vm.Src.Id, "hostIP").Val()
+	agent_address.WriteString(podIP)
+	logger.Info("Connecting to pod at: " + podIP)
+	agent_address.WriteString(":")
+	agent_address.WriteString(strconv.Itoa(constants.AGENT_GRPC_SERVER_PORT))
+	conn, err := grpc.Dial(agent_address.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		logger.Info("Failed to dial gRPC server address: "+agent_address.String(), err)
+		return err
+	}
+
+	client := agent_pb.NewMerakAgentServiceClient(conn)
+	logger.Info("Sending to agent at" + podIP)
+	name := common.RedisClient.HGet(ctx, vm.Src.Id, "name").Val()
+	destName := common.RedisClient.HGet(ctx, vm.Dest.Id, "name").Val()
+	destIP := common.RedisClient.HGet(ctx, vm.Dest.Id, "ip").Val()
+	srcIP := common.RedisClient.HGet(ctx, vm.Src.Id, "ip").Val()
+	test := agent_pb.InternalTestConfig{
+		TestType: pb.TestType_PING,
+		Name:     name,
+		DestIp:   destIP,
+		SrcPort:  vm.Src.Port,
+		DestPort: vm.Dest.Port,
+	}
+	resp, err := client.TestHandler(ctx, &test)
+	if err != nil {
+		logger.Error("Unable to start vm test on" + podIP + "Reason: " + resp.GetReturnMessage() + "\n")
+		if err := common.RedisClient.HSet(
+			ctx,
+			constants.TEST_PREFIX+vm.Src.Id,
+			"status",
+			"2",
+		).Err(); err != nil {
+			logger.Info("Failed to add err test response to DB!")
+			return err
+		}
+		return err
+	}
+
+	// Update DB with device information
+	if resp.ReturnCode == commonPB.ReturnCode_OK {
+		status := resp.Status
+		logger.Info("Test Success for " + name + "on pod IP " + podIP)
+		if err := common.RedisClient.HSet(
+			ctx,
+			constants.TEST_PREFIX+vm.Src.Id,
+			"id",
+			vm.Src.Id,
+			"name",
+			name,
+			"src",
+			srcIP,
+			"dest",
+			destIP,
+			"srcPort",
+			vm.Src.Port,
+			"destPort",
+			vm.Dest.Port,
+			"destID",
+			vm.Dest.Id,
+			"destName",
+			destName,
+			"status",
+			strconv.Itoa(int(status.Number())),
+		).Err(); err != nil {
+			logger.Info("Failed to add Test response to DB!")
+			return err
+		}
+	}
+	logger.Info("Response from agent at address " + podIP + ": " + resp.GetReturnMessage())
+
+	defer conn.Close()
+	return nil
+}

--- a/services/merak-ntest/common/common.go
+++ b/services/merak-ntest/common/common.go
@@ -1,0 +1,45 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package common
+
+import (
+	"time"
+
+	"github.com/go-redis/redis/v9"
+)
+
+var RedisClient redis.Client
+
+const (
+	TEMPORAL_SUCESS_CODE = "SUCCESS"
+	TEMPORAL_FAIL_CODE   = "FAILED"
+
+	TEMPORAL_WF_TASK_TIMEOUT = time.Second * 30
+	TEMPORAL_WF_EXEC_TIMEOUT = time.Second * 30
+	TEMPORAL_WF_RUN_TIMEOUT  = time.Second * 30
+
+	TEMPORAL_WF_RETRY_INTERVAL = time.Second
+	TEMPORAL_WF_BACKOFF        = 1
+	TEMPORAL_WF_MAX_INTERVAL   = time.Second * 10
+	TEMPORAL_WF_MAX_ATTEMPT    = 1
+
+	TEMPORAL_ACTIVITY_RETRY_INTERVAL = time.Second
+	TEMPORAL_ACTIVITY_BACKOFF        = 1
+	TEMPORAL_ACTIVITY_MAX_INTERVAL   = time.Second * 10
+	TEMPORAL_ACTIVITY_MAX_ATTEMPT    = 1
+	TEMPORAL_ACTIVITY_TIMEOUT        = 600 * time.Second
+
+	NTEST_TASK_QUEUE         = "NTEST_TASK_QUEUE"
+	NTEST_CREATE_WORKFLOW_ID = "NTEST_CREATE_WORKFLOW"
+)

--- a/services/merak-ntest/handler/create.go
+++ b/services/merak-ntest/handler/create.go
@@ -1,0 +1,60 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package handler
+
+import (
+	"context"
+	"log"
+
+	commonPB "github.com/futurewei-cloud/merak/api/proto/v1/common"
+	pb "github.com/futurewei-cloud/merak/api/proto/v1/ntest"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/common"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/workflows/create"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+)
+
+func caseCreate(ctx context.Context, in *pb.InternalTestConfiguration) (*pb.ReturnTestMessage, error) {
+
+	retrypolicy := &temporal.RetryPolicy{
+		InitialInterval:    common.TEMPORAL_WF_RETRY_INTERVAL,
+		BackoffCoefficient: common.TEMPORAL_WF_BACKOFF,
+		MaximumInterval:    common.TEMPORAL_WF_MAX_INTERVAL,
+		MaximumAttempts:    common.TEMPORAL_WF_MAX_ATTEMPT,
+	}
+
+	log.Println("Operation Create")
+
+	// Execute VM creation on a per pod basis
+	// Send a list of VMs to the Workflow
+	workflowOptions = client.StartWorkflowOptions{
+		ID:          common.NTEST_CREATE_WORKFLOW_ID,
+		TaskQueue:   common.NTEST_TASK_QUEUE,
+		RetryPolicy: retrypolicy,
+	}
+	log.Println("Executing Ntest Create Workflow with")
+	we, err := TemporalClient.ExecuteWorkflow(context.Background(), workflowOptions, create.Create, in)
+	if err != nil {
+		return &pb.ReturnTestMessage{
+			ReturnMessage: "Unable to execute Ntest create workflow",
+		}, err
+	}
+	log.Println("Started Create workflow WorkflowID "+we.GetID()+" RunID ", we.GetRunID())
+
+	return &pb.ReturnTestMessage{
+		ReturnMessage: "Successfully started all create workflows!",
+		ReturnCode:    commonPB.ReturnCode_OK,
+	}, nil
+}

--- a/services/merak-ntest/handler/delete.go
+++ b/services/merak-ntest/handler/delete.go
@@ -1,0 +1,47 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package handler
+
+import (
+	"context"
+	"log"
+
+	commonPB "github.com/futurewei-cloud/merak/api/proto/v1/common"
+	pb "github.com/futurewei-cloud/merak/api/proto/v1/ntest"
+	constants "github.com/futurewei-cloud/merak/services/common"
+)
+
+func caseDelete(ctx context.Context, in *pb.InternalTestConfiguration) (*pb.ReturnTestMessage, error) {
+
+	log.Println("Operation Delete")
+
+	ids := RedisClient.SMembers(ctx, constants.NTEST_VM_SET)
+	if ids.Err() != nil {
+		log.Println("Unable to get VM IDs from redis", ids.Err())
+
+		return &pb.ReturnTestMessage{
+			ReturnCode:    commonPB.ReturnCode_FAILED,
+			ReturnMessage: "Unable to get VM IDs from redis",
+		}, ids.Err()
+	}
+	for _, vmID := range ids.Val() {
+		RedisClient.HDel(ctx, vmID)
+	}
+	RedisClient.Del(ctx, constants.NTEST_VM_SET)
+	return &pb.ReturnTestMessage{
+		ReturnMessage: "Successfully started all create workflows!",
+		ReturnCode:    commonPB.ReturnCode_OK,
+	}, nil
+}

--- a/services/merak-ntest/handler/info.go
+++ b/services/merak-ntest/handler/info.go
@@ -1,0 +1,91 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package handler
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	commonPB "github.com/futurewei-cloud/merak/api/proto/v1/common"
+	pb "github.com/futurewei-cloud/merak/api/proto/v1/ntest"
+	constants "github.com/futurewei-cloud/merak/services/common"
+)
+
+func caseInfo(ctx context.Context, in *pb.InternalTestConfiguration) (*pb.ReturnTestMessage, error) {
+	log.Println("Operation Info")
+	ids := RedisClient.SMembers(ctx, constants.NTEST_VM_SET)
+	if ids.Err() != nil {
+		log.Println("Unable to get VM IDs from redis", ids.Err())
+
+		return &pb.ReturnTestMessage{
+			ReturnCode:    commonPB.ReturnCode_FAILED,
+			ReturnMessage: "Unable to get VM IDs from redis",
+		}, ids.Err()
+	}
+	vms := []*pb.InternalVMTestResult{}
+	log.Println("Success in getting VM IDs!")
+	for _, vmID := range ids.Val() {
+		srcPort, err := RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "srcPort").Int()
+		if err != nil {
+			log.Println("Failed to find port for vm " + vmID)
+			srcPort = -1
+		}
+
+		src := pb.InternalVMHostInfo{
+			Id:   RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "id").Val(),
+			Ip:   RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "ip").Val(),
+			Name: RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "name").Val(),
+			Port: int32(srcPort),
+		}
+
+		dest := pb.InternalVMHostInfo{
+			Id:   RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "destID").Val(),
+			Ip:   RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "dest").Val(),
+			Name: RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "name").Val(),
+			Port: int32(srcPort),
+		}
+		vm := pb.InternalVMTestResult{
+			Src:  &src,
+			Dest: &dest,
+		}
+		status, err := strconv.Atoi(RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "status").Val())
+		if err != nil {
+			log.Println("Failed to convert status string to int!", err)
+			return &pb.ReturnTestMessage{
+				ReturnCode:    commonPB.ReturnCode_FAILED,
+				ReturnMessage: "Failed to convert status string to int!",
+				Results:       vms,
+			}, err
+		}
+		testType, err := strconv.Atoi(RedisClient.HGet(ctx, constants.TEST_PREFIX+vmID, "testType").Val())
+		if err != nil {
+			return &pb.ReturnTestMessage{
+				ReturnCode:    commonPB.ReturnCode_FAILED,
+				ReturnMessage: "Failed to convert testType string to int!",
+				Results:       vms,
+			}, err
+		}
+		vm.Status = pb.TestStatus(status)
+		vm.TestType = pb.TestType(testType)
+		vms = append(vms, &vm)
+	}
+
+	return &pb.ReturnTestMessage{
+		ReturnCode:    commonPB.ReturnCode_OK,
+		ReturnMessage: "Success!",
+		Results:       vms,
+	}, nil
+}

--- a/services/merak-ntest/module.mk
+++ b/services/merak-ntest/module.mk
@@ -1,0 +1,17 @@
+# MIT License
+# Copyright(c) 2022 Futurewei Cloud
+#     Permission is hereby granted,
+#     free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+#     including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+#     to whom the Software is furnished to do so, subject to the following conditions:
+#     The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+module := merak-ntest
+
+merak-ntest: ntest
+
+ntest:
+	$(GFLAGS) go build -o services/merak-ntest/build/merak-ntest services/merak-ntest/ntest.go

--- a/services/merak-ntest/module.mk
+++ b/services/merak-ntest/module.mk
@@ -11,7 +11,9 @@
 
 module := merak-ntest
 
-merak-ntest: ntest
+merak-ntest: ntest ntest-worker
 
 ntest:
 	$(GFLAGS) go build -o services/merak-ntest/build/merak-ntest services/merak-ntest/ntest.go
+ntest-worker:
+	$(GFLAGS) go build -o services/merak-ntest/build/merak-ntest-worker services/merak-ntest/workers/worker.go

--- a/services/merak-ntest/ntest.go
+++ b/services/merak-ntest/ntest.go
@@ -1,0 +1,95 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	pb "github.com/futurewei-cloud/merak/api/proto/v1/ntest"
+	constants "github.com/futurewei-cloud/merak/services/common"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/handler"
+	"github.com/go-redis/redis/v9"
+	"go.temporal.io/sdk/client"
+	"google.golang.org/grpc"
+)
+
+var (
+	ctx  = context.Background()
+	Port = flag.Int("port", constants.NTEST_GRPC_SERVER_PORT, "The server port")
+)
+
+func main() {
+	// Connect to temporal
+	temporal_address, ok := os.LookupEnv(constants.TEMPORAL_ENV)
+	if !ok {
+		log.Println("Temporal environment variable not set, using default address.")
+		temporal_address = constants.TEMPORAL_ADDRESS
+	}
+	var sb strings.Builder
+	sb.WriteString(temporal_address)
+	sb.WriteString(":")
+	sb.WriteString(strconv.Itoa(constants.TEMPORAL_PORT))
+	var err error
+	log.Printf("Connecting to Temporal server at %s", sb.String())
+
+	handler.TemporalClient, err = client.Dial(client.Options{
+		HostPort: sb.String(),
+	})
+	if err != nil {
+		log.Fatalln("ERROR: Unable to create Temporal client", err)
+	}
+	log.Println("Successfully connected to Temporal!")
+	defer handler.TemporalClient.Close()
+
+	//Connect to Redis
+	var redisAddress strings.Builder
+	redisAddress.WriteString(constants.COMPUTE_REDIS_ADDRESS)
+	redisAddress.WriteString(":")
+	redisAddress.WriteString(strconv.Itoa(constants.COMPUTE_REDIS_PORT))
+	handler.RedisClient = *redis.NewClient(&redis.Options{
+		Addr:     redisAddress.String(),
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
+	err = handler.RedisClient.Set(ctx, "key", "value", 0).Err()
+	if err != nil {
+		log.Fatalln("ERROR: Unable to create Redis client", err)
+	}
+	log.Println("Successfully connected to Redis!")
+	defer handler.RedisClient.Close()
+
+	//Start gRPC Server
+	flag.Parse()
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *Port))
+	if err != nil {
+		log.Fatalln("ERROR: Failed to listen", err)
+	}
+	gRPCServer := grpc.NewServer(
+		grpc.MaxSendMsgSize(constants.GRPC_MAX_SEND_MSG_SIZE),
+		grpc.MaxRecvMsgSize(constants.GRPC_MAX_RECV_MSG_SIZE))
+	pb.RegisterMeraknTestServiceServer(gRPCServer, &handler.Server{})
+	log.Printf("Starting gRPC server. Listening at %v", lis.Addr())
+	if err := gRPCServer.Serve(lis); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+
+}

--- a/services/merak-ntest/workers/worker.go
+++ b/services/merak-ntest/workers/worker.go
@@ -1,0 +1,82 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+    Permission is hereby granted,
+    free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+    to whom the Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	constants "github.com/futurewei-cloud/merak/services/common"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/activities"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/common"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/workflows/create"
+	"github.com/go-redis/redis/v9"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
+)
+
+var ctx = context.Background()
+
+func main() {
+	temporal_address, ok := os.LookupEnv(constants.TEMPORAL_ENV)
+	if !ok {
+		log.Println("Temporal environment variable not set, using default address.")
+		temporal_address = constants.TEMPORAL_ADDRESS
+	}
+	var sb strings.Builder
+	sb.WriteString(temporal_address)
+	sb.WriteString(":")
+	sb.WriteString(strconv.Itoa(constants.TEMPORAL_PORT))
+
+	c, err := client.Dial(client.Options{
+		HostPort: sb.String(),
+	})
+	if err != nil {
+		log.Fatalln("Unable to create client", err)
+	}
+	log.Println("Connected to Temporal!")
+	defer c.Close()
+
+	//Connect to Redis
+	var redisAddress strings.Builder
+	redisAddress.WriteString(constants.COMPUTE_REDIS_ADDRESS)
+	redisAddress.WriteString(":")
+	redisAddress.WriteString(strconv.Itoa(constants.COMPUTE_REDIS_PORT))
+
+	common.RedisClient = *redis.NewClient(&redis.Options{
+		Addr:     redisAddress.String(),
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	})
+
+	err = common.RedisClient.Set(ctx, "key", "value", 0).Err()
+	if err != nil {
+		log.Fatalln("ERROR: Unable to create Redis client", err)
+	}
+	defer common.RedisClient.Close()
+	log.Println("Connected to DB!")
+
+	w := worker.New(c, common.NTEST_TASK_QUEUE, worker.Options{})
+	w.RegisterWorkflow(create.Create)
+	w.RegisterActivity(activities.NtestCreate)
+	log.Println("Registered Ntest Workflows and activities.")
+	log.Println("Starting Ntest Worker.")
+	err = w.Run(worker.InterruptCh())
+	if err != nil {
+		log.Fatalln("Unable to start worker", err)
+	}
+}

--- a/services/merak-ntest/workflows/create/create.go
+++ b/services/merak-ntest/workflows/create/create.go
@@ -1,0 +1,77 @@
+/*
+MIT License
+Copyright(c) 2022 Futurewei Cloud
+
+	Permission is hereby granted,
+	free of charge, to any person obtaining a copy of this software and associated documentation files(the "Software"), to deal in the Software without restriction,
+	including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and / or sell copies of the Software, and to permit persons
+	to whom the Software is furnished to do so, subject to the following conditions:
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+	WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package create
+
+import (
+	"context"
+
+	pb "github.com/futurewei-cloud/merak/api/proto/v1/ntest"
+	constants "github.com/futurewei-cloud/merak/services/common"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/activities"
+	"github.com/futurewei-cloud/merak/services/merak-ntest/common"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
+)
+
+func Create(ctx workflow.Context, in *pb.InternalTestConfiguration) (err error) {
+	retrypolicy := &temporal.RetryPolicy{
+		InitialInterval:    common.TEMPORAL_ACTIVITY_RETRY_INTERVAL,
+		BackoffCoefficient: common.TEMPORAL_ACTIVITY_BACKOFF,
+		MaximumInterval:    common.TEMPORAL_ACTIVITY_MAX_INTERVAL,
+		MaximumAttempts:    common.TEMPORAL_ACTIVITY_MAX_ATTEMPT,
+	}
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: common.TEMPORAL_ACTIVITY_TIMEOUT,
+		RetryPolicy:         retrypolicy,
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, ao)
+	logger := workflow.GetLogger(ctx)
+	redisCtx := context.Background()
+	var futures []workflow.Future
+	for _, vm := range in.Vms {
+		if err := common.RedisClient.SAdd(
+			redisCtx,
+			constants.NTEST_VM_SET,
+			constants.TEST_PREFIX+vm.Src.Id,
+			"testType",
+			vm.TestType.String(),
+		).Err(); err != nil {
+			return err
+		}
+		if err := common.RedisClient.HSet(
+			redisCtx,
+			constants.TEST_PREFIX+vm.Src.Id,
+			"status",
+			"0",
+		).Err(); err != nil {
+			logger.Info("Failed to add Test response to DB!")
+			return err
+		}
+		future := workflow.ExecuteActivity(ctx, activities.NtestCreate, vm)
+		logger.Info("NtestCreate activity started for vm_id " + vm.String())
+		futures = append(futures, future)
+	}
+	logger.Info("Started NtestCreate workflows for vms")
+
+	for _, future := range futures {
+		err = future.Get(ctx, nil)
+		logger.Info("Activity completed!")
+		if err != nil {
+			return err
+		}
+	}
+	logger.Info("All activities completed")
+	return nil
+}

--- a/services/module.mk
+++ b/services/module.mk
@@ -11,7 +11,7 @@
 
 module := services
 
-submodules := proto merak-compute scenario-manager merak-agent merak-network merak-topo
+submodules := proto merak-compute scenario-manager merak-agent merak-network merak-topo merak-ntest
 -include $(patsubst %, $(module)/%/module.mk, $(submodules))
 
 all:: $(submodules)


### PR DESCRIPTION
This PR adds the following

- Initial Implementation of Merak Ntest.
  - Exposes a gRPC interface to run tests on created VMs
  - The current available test types are
     - Ping between two VMs