### PR TITLE
If can't connect to db on k8s, it will cause the pod to restart, then…

### DIFF
--- a/services/merak-network/database/database.go
+++ b/services/merak-network/database/database.go
@@ -39,7 +39,7 @@ func ConnectDatabase() error {
 	})
 
 	if err := client.Ping(Ctx).Err(); err != nil {
-		log.Printf("DB ConnectDatabase Issue: %s", err.Error())
+		log.Fatalf("DB ConnectDatabase Issue: %s", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
… connect again.
Fix #136 

This PR enable Merak-Network to restart it's pod in k8s env during deploy, in the case of DB pod not ready yet. 
Then after the DB pod is ready, Merak-Network pod will be able to successfully connect to it. 