### PR TITLE
Add concurrency and RPS env variables

### DIFF
--- a/deployments/kubernetes/compute.dev.yaml
+++ b/deployments/kubernetes/compute.dev.yaml
@@ -82,6 +82,10 @@ spec:
         env:
         - name: "TEMPORAL"
           value: "temporaltest-frontend.default.svc.cluster.local"
+        - name: RPS
+          value: "1000"
+        - name: CONCURRENCY
+          value: "1000"
 # Single Redis Leader.
 # TODO: Add followers and follower service
 ---

--- a/deployments/kubernetes/compute.test.yaml
+++ b/deployments/kubernetes/compute.test.yaml
@@ -13,7 +13,6 @@ kind: Namespace
 metadata:
   name: merak
 ---
----
 # Test service account
 apiVersion: v1
 kind: ServiceAccount
@@ -78,6 +77,10 @@ spec:
         env:
         - name: "TEMPORAL"
           value: "temporaltest-frontend.default.svc.cluster.local"
+        - name: RPS
+          value: "1000"
+        - name: CONCURRENCY
+          value: "1000"
 ---
 # Merak Compute VM Worker Deployment
 apiVersion: apps/v1

--- a/services/common/constants.go
+++ b/services/common/constants.go
@@ -1,11 +1,13 @@
 package constants
 
 const (
-	TEMPORAL_ADDRESS   = "temporaltest-frontend.default.svc.cluster.local"
-	TEMPORAL_PORT      = 7233
-	TEMPORAL_ENV       = "TEMPORAL"
-	LOCALHOST          = "127.0.0.1"
-	TEMPORAL_NAMESPACE = "merak"
+	TEMPORAL_ADDRESS         = "temporaltest-frontend.default.svc.cluster.local"
+	TEMPORAL_PORT            = 7233
+	TEMPORAL_ENV             = "TEMPORAL"
+	TEMPORAL_RPS_ENV         = "RPS"
+	TEMPORAL_CONCURRENCY_ENV = "CONCURRENCY"
+	LOCALHOST                = "127.0.0.1"
+	TEMPORAL_NAMESPACE       = "merak"
 
 	COMPUTE_GRPC_SERVER_ADDRESS         = "merak-compute-service.merak.svc.cluster.local"
 	COMPUTE_GRPC_SERVER_ADDRESS_DEFAULT = "merak-compute-service.default.svc.cluster.local"


### PR DESCRIPTION
This PR does the following:

1. Allows for users to specify max concurrent activities/worker and worker activities/sec from the yaml environment variables
2. Users can modify these parameters by changing their values in the yaml file and reapplying the worker deployment with kubectl