### PR TITLE
README reorg and kind delete before create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ docker-all-ci:
 
 .PHONY: kind
 kind:
+	kind delete cluster
 	kind create cluster --config=configs/kind.yaml
 	linkerd install --crds | kubectl apply -f -
 	linkerd install | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In order to provide more virtual and emulated resources with limited hardware re
 
 For more detail design and information, please refer to the docs folder in this repository.
 
-## [Kind](https://kind.sigs.k8s.io): Simple Test
+## [Kind](https://kind.sigs.k8s.io): Simple Deployment and E2E Test
 
 This test will bring up Merak and [Alcor](https://github.com/futurewei-cloud/alcor) in a
 single master node [Kind](https://kind.sigs.k8s.io) Kubernetes cluster.
@@ -45,6 +45,10 @@ single master node [Kind](https://kind.sigs.k8s.io) Kubernetes cluster.
   - 16GB RAM
   - 8 Core CPU
 
+- Update
+```
+sudo apt-get update
+```
 - [Make](https://www.gnu.org/software/make/)
 ```
 sudo apt-get install make
@@ -92,7 +96,7 @@ before proceeding to the next step. This should take approximately 5 minutes.
 
 ![Successful Merak Deployment](docs/images/merak_successful_deployment.jpg)
 
-### Step 2: Run test
+### Step 2: Run The Test
 
 You can use the prebuilt test tool as shown below.
 
@@ -118,7 +122,7 @@ Run the command below to clean up the [Kind](https://kind.sigs.k8s.io) environme
 kind delete cluster
 ```
 
-## Getting started with development
+## Getting Started With Development
 
 To build this project, please make sure the following things are installed:
 
@@ -133,7 +137,7 @@ Then, the project can be built with:
 make
 ```
 
-## How to deploy
+## How to Deploy a Development Cluster
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,90 @@ In order to provide more virtual and emulated resources with limited hardware re
 
 For more detail design and information, please refer to the docs folder in this repository.
 
+### [Kind](https://kind.sigs.k8s.io): Simple Test
+
+This test will bring up Merak and [Alcor](https://github.com/futurewei-cloud/alcor) in a
+single master node [Kind](https://kind.sigs.k8s.io) Kubernetes cluster.
+
+### Prerequisites
+
+- Minimum Machine Requirements (Our tests were ran on AWS t2.2xlarge ec2 instances)
+  - 16GB RAM
+  - 8 Core CPU
+
+- [Make](https://www.gnu.org/software/make/)
+```
+sudo apt-get install make
+```
+- [Helm](https://helm.sh/docs/intro/install/)
+```
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+```
+- [Linkerd CLI](https://linkerd.io/2.12/getting-started/)
+```
+curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
+export PATH=$PATH:/home/ubuntu/.linkerd2/bin
+```
+- [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+```
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+```
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
+```
+curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+```
+- [Docker](https://www.docker.com)
+```
+sudo apt-get install docker.io
+```
+  - Add current user to docker group (for running docker without sudo)
+```
+sudo groupadd docker
+sudo gpasswd -a $USER docker
+newgrp docker
+```
+
+### Step 1: Deploy
+
+You can deploy Merak and [Alcor](https://github.com/futurewei-cloud/alcor) in [Kind](https://kind.sigs.k8s.io) with the command below.
+
+```
+git clone https://github.com/futurewei-cloud/merak.git
+cd merak
+make kind
+```
+
+Please wait for all pods to be in running state as shown in the picture below
+before proceeding to the next step. This should take approximately 5 minutes.
+
+![Successful Merak Deployment](docs/images/merak_successful_deployment.jpg)
+
+### Step 2: Run test
+
+You can use the prebuilt test tool as shown below.
+
+```
+./tools/teste2e/bin/teste2e
+```
+
+This will create 10 hosts with 1 VM each.
+Once everything is created, you can test network connnectivity as shown below.
+
+1. Run ```kubectl get pods -A``` to see all vhost pods.
+![Step 1](docs/images/merak_e2e_step1.jpg)
+
+1. Merak uses network namespaces to emulate VMs, run ``` kubectl exec -it vhost-0 ip netns exec v000 ip a ``` to get the IP address of the emulated VM `v000` inside of the emulated host `vhost-0`.
+![Step 2](docs/images/merak_e2e_step2.jpg)
+
+1. Ping the VM `v000` on `vhost-0` from a different VM on `vhost-1` with the following command ``` kubectl exec -it vhost-1 ip netns exec v000 ping (IP address from step 2)```
+![Step 2](docs/images/merak_e2e_step3.jpg)
+
+### Clean-up:
+Run the command below to clean up the [Kind](https://kind.sigs.k8s.io) environment.
+```
+kind delete cluster
+```
+
 ## Getting started with development
 
 To build this project, please make sure the following things are installed:
@@ -106,88 +190,4 @@ The deployment settings such as container image and replicas can be changed by e
 
 ```
 kubectl kustomize deployments/kubernetes/dev --enable-helm | kubectl apply -f -
-```
-
-### [Kind](https://kind.sigs.k8s.io): Simple Test
-
-This test will bring up Merak and [Alcor](https://github.com/futurewei-cloud/alcor) in a
-single master node [Kind](https://kind.sigs.k8s.io) Kubernetes cluster.
-
-#### Prerequisites
-
-- Minimum Machine Requirements (Our tests were ran on AWS t2.2xlarge ec2 instances)
-  - 16GB RAM
-  - 8 Core CPU
-
-- [Make](https://www.gnu.org/software/make/)
-```
-sudo apt-get install make
-```
-- [Helm](https://helm.sh/docs/intro/install/)
-```
-curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-```
-- [Linkerd CLI](https://linkerd.io/2.12/getting-started/)
-```
-curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
-export PATH=$PATH:/home/ubuntu/.linkerd2/bin
-```
-- [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
-```
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
-```
-- [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-```
-curl -LO https://dl.k8s.io/release/v1.26.0/bin/linux/amd64/kubectl && sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-```
-- [Docker](https://www.docker.com)
-```
-sudo apt-get install docker.io
-```
-  - Add current user to docker group (for running docker without sudo)
-```
-sudo groupadd docker
-sudo gpasswd -a $USER docker
-newgrp docker
-```
-
-#### Step 1: Deploy
-
-You can deploy Merak and [Alcor](https://github.com/futurewei-cloud/alcor) in [Kind](https://kind.sigs.k8s.io) with the command below.
-
-```
-git clone https://github.com/futurewei-cloud/merak.git
-cd merak
-make kind
-```
-
-Please wait for all pods to be in running state as shown in the picture below
-before proceeding to the next step. This should take approximately 5 minutes.
-
-![Successful Merak Deployment](docs/images/merak_successful_deployment.jpg)
-
-#### Step 2: Run test
-
-You can use the prebuilt test tool as shown below.
-
-```
-./tools/teste2e/bin/teste2e
-```
-
-This will create 10 hosts with 1 VM each.
-Once everything is created, you can test network connnectivity as shown below.
-
-1. Run ```kubectl get pods -A``` to see all vhost pods.
-![Step 1](docs/images/merak_e2e_step1.jpg)
-
-1. Merak uses network namespaces to emulate VMs, run ``` kubectl exec -it vhost-0 ip netns exec v000 ip a ``` to get the IP address of the emulated VM `v000` inside of the emulated host `vhost-0`.
-![Step 2](docs/images/merak_e2e_step2.jpg)
-
-1. Ping the VM `v000` on `vhost-0` from a different VM on `vhost-1` with the following command ``` kubectl exec -it vhost-1 ip netns exec v000 ping (IP address from step 2)```
-![Step 2](docs/images/merak_e2e_step3.jpg)
-
-#### Clean-up:
-Run the command below to clean up the [Kind](https://kind.sigs.k8s.io) environment.
-```
-kind delete cluster
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In order to provide more virtual and emulated resources with limited hardware re
 
 For more detail design and information, please refer to the docs folder in this repository.
 
-### [Kind](https://kind.sigs.k8s.io): Simple Test
+## [Kind](https://kind.sigs.k8s.io): Simple Test
 
 This test will bring up Merak and [Alcor](https://github.com/futurewei-cloud/alcor) in a
 single master node [Kind](https://kind.sigs.k8s.io) Kubernetes cluster.


### PR DESCRIPTION
This PR does the following:
- Reorganizes the readme such that users will see the kind simple test first
- delete kind cluster before create in make kind