### PR TITLE
Topo: add hostname attribute for each pod

### DIFF
--- a/api/proto/v1/common.proto
+++ b/api/proto/v1/common.proto
@@ -74,6 +74,7 @@ message InternalComputeInfo {
   string veth = 6;
   string container_ip = 7;
   Status status = 8;
+  string hostname = 9;
 }
 
 message InternalSubnetInfo {

--- a/services/merak-topo/database/entities.go
+++ b/services/merak-topo/database/entities.go
@@ -84,4 +84,5 @@ type ComputeNode struct {
 	Veth          string        `json:"veth"`
 	ContainerIp   string        `json:"container_ip"`
 	Status        ServiceStatus `json:"status"`
+	HostName      string        `json:"hostname"`
 }

--- a/services/merak-topo/handler/handler.go
+++ b/services/merak-topo/handler/handler.go
@@ -307,6 +307,7 @@ func UpdateComputenodeInfo(k8client *kubernetes.Clientset, topo_id string) error
 				cnode.Veth = node.Nics[len(node.Nics)-1].Intf
 				if res.Status.PodIP != "" {
 					cnode.ContainerIp = res.Status.PodIP
+					cnode.HostName = res.Spec.NodeName
 				} else {
 					log.Printf("pod ip is not ready %v", res.Name)
 				}
@@ -409,6 +410,8 @@ func Info(k8client *kubernetes.Clientset, topo_id string, returnMessage *pb.Retu
 			crm.ContainerIp = cnode.ContainerIp
 			crm.Mac = cnode.Mac
 			crm.Veth = cnode.Veth
+			crm.Hostname = cnode.HostName
+
 			if cnode.Status == database.STATUS_READY {
 				crm.Status = pb_common.Status_READY
 			} else if cnode.Status == database.STATUS_DELETING {


### PR DESCRIPTION
This PR make three changes:
1) add `hostname` field into `common.InternalComputeInfo`
2) add `hostname` field into merak-topo's `ComputeNode` entity.
3) add code to retrieve NodeName for each pod in the merak-topo with `pod.Spec.NodeName`