### PR TITLE
Scenario: allowing different size of VPC to be deployed in the compute

### DIFF
--- a/services/scenario-manager/handler/deploy.go
+++ b/services/scenario-manager/handler/deploy.go
@@ -224,7 +224,7 @@ func ComputeHanlder(s *entities.Scenario, action entities.EventName) (*compute_p
 	var computeconf compute_pb.InternalComputeConfigInfo
 	if action == entities.EVENT_CHECK {
 		if err := constructComputeMessage(&compute, nil, nil, nil, &computeconf, action); err != nil {
-			return nil, errors.New("compute config protobuf message error")
+			return nil, err
 		}
 	} else {
 		var service entities.ServiceConfig

--- a/services/scenario-manager/handler/deploy.go
+++ b/services/scenario-manager/handler/deploy.go
@@ -253,16 +253,9 @@ func ComputeHanlder(s *entities.Scenario, action entities.EventName) (*compute_p
 		}
 
 		if err := constructComputeMessage(&compute, &service, returnTopo, returnNetwork, &computeconf, action); err != nil {
-			return nil, errors.New("compute config protobuf message error")
+			return nil, err
 		}
 
-		for _, n := range returnNetwork.GetVpcs() {
-			for _, s := range n.GetSubnets() {
-				if compute.NumberOfComputeNodes != 0 && len(n.GetSubnets()) != 0 {
-					s.NumberVms = uint32(compute.NumberOfVmPerVpc) / uint32(compute.NumberOfComputeNodes) / uint32(len(n.GetSubnets()))
-				}
-			}
-		}
 		logger.Log.Infof("after returnNetworkMessage: %s", returnNetwork)
 	}
 

--- a/services/scenario-manager/handler/message.go
+++ b/services/scenario-manager/handler/message.go
@@ -285,12 +285,12 @@ func constructComputeMessage(compute *entities.ComputeConfig, serviceConf *entit
 		}
 	} else {
 		vmDeployPb.Vpcs = netReturn.GetVpcs()
-		for _, n := range netReturn.GetVpcs() {
-			for _, s := range n.GetSubnets() {
-				if compute.NumberOfComputeNodes != 0 && len(n.GetSubnets()) != 0 {
-					s.NumberVms = uint32(compute.NumberOfVmPerVpc) / uint32(compute.NumberOfComputeNodes) / uint32(len(n.GetSubnets()))
+		for _, vpc := range vmDeployPb.GetVpcs() {
+			for _, subnet := range vpc.GetSubnets() {
+				if compute.NumberOfComputeNodes != 0 && len(vpc.GetSubnets()) != 0 {
+					subnet.NumberVms = uint32(compute.NumberOfVmPerVpc) / uint32(compute.NumberOfComputeNodes) / uint32(len(vpc.GetSubnets()))
 				}
-				if s.NumberVms <= 0 {
+				if subnet.NumberVms <= 0 {
 					return errors.New("number of VMs to be deployed in a VPC are zero")
 				}
 			}

--- a/services/scenario-manager/handler/message.go
+++ b/services/scenario-manager/handler/message.go
@@ -277,7 +277,10 @@ func constructComputeMessage(compute *entities.ComputeConfig, serviceConf *entit
 				}
 				for _, subnet := range vpc.SubnetInfo {
 					var subnetPb pb.InternalSubnetInfo
-					subnetPb.NumberVms = uint32(subnet.NumberOfVMs)
+					subnetPb.NumberVms = uint32(subnet.NumberOfVMs) / uint32(compute.NumberOfComputeNodes)
+					if subnetPb.NumberVms <= 0 {
+						return errors.New("construt compute message - number of compute nodes larger than number of VMs per vpc")
+					}
 					subnetPb.SubnetCidr = subnet.SubnetCidr
 					subnetPb.SubnetGw = subnet.SubnetGateway
 					vpcPb.Subnets = append(vpcPb.Subnets, &subnetPb)

--- a/services/scenario-manager/handler/message.go
+++ b/services/scenario-manager/handler/message.go
@@ -256,8 +256,6 @@ func constructComputeMessage(compute *entities.ComputeConfig, serviceConf *entit
 	vmDeployPb.OperationType = actionToOperation(action)
 	if netReturn != nil {
 		vmDeployPb.Secgroups = netReturn.GetSecurityGroupIds()
-	} else {
-		return errors.New("the virtual newtork is not ready, there is no VPC info exist")
 	}
 	vmDeployPb.DeployType = getVMDeployType(compute.VmDeployType)
 	vmDeployPb.Scheduler = getVMDeployScheduler(compute.Scheduler)


### PR DESCRIPTION
This PR make the input of compute_info change as follow:
1)  accept two types of `vm_deploy_type`: `UNIFORM` or `ASSIGN`
2) `UNIFORM` will spread out the `number_of_vm_per_vpc` into each subnet of vpc in each compute node, i.e. 
`subnet.NumberVms = NumberOfVmPerVpc / NumberOfComputeNodes / len(vpc.GetSubnets())`
3) `ASSIGN` will parse the `vpc_info` and `subnet_info` in the compute config and send the protobuf to merak-compute.
```
"vm_deploy_type": "ASSIGN",
"vpc_info": [
        {
            "tenant_id": "123456789",
            "project_id": "123456789",
            "vpc_cidr": "10.1.0.0/16",
            "number_of_subnets": 1,
            "subnet_info": [
                {
                    "subnet_cidr": "10.1.0.0/16",
                    "subnet_gateway": "10.1.0.1",
                    "number_of_vms": 10000
                }
            ]
        }
    ]
```